### PR TITLE
修复在strategy.compose_training_data时会有越界崩溃问题

### DIFF
--- a/autophrasex/autophrase.py
+++ b/autophrasex/autophrase.py
@@ -41,6 +41,10 @@ class AutoPhrase:
         # TODO: 第一次构建正负池的时候，把unigrams作为正样本
         # TODO: 观察训练过程，调整threshold_schedule_factor的值，有可能需要小于1
 
+        initial_pos_pool, initial_neg_pool = strategy.filter_pools(initial_pos_pool, initial_neg_pool)
+        logging.info('valid size of initial positive pool: %d', len(initial_pos_pool))
+        logging.info('valid size of initial negative pool: %d', len(initial_neg_pool))
+
         pos_pool, neg_pool = initial_pos_pool, initial_neg_pool
         for epoch in range(kwargs.pop('epochs', 5)):
             logging.info('Starting to train model at epoch %d ...', epoch + 1)


### PR DESCRIPTION
1.修复在strategy.compose_training_data时如果样本的ngram再次tokenize后不在self.ngrams_callback.ngrams_freq中时会有越界崩溃问题；增加filter_pools过滤样本接口

2. 不知道你发现会出现这个问题么？我用了大点的篇章测试发现会有这个现象，就是根据我的理解build_phrase_pool后，按理所有样本的ngram应该都已经存在self.ngrams_callback.ngrams_freq中了，但是在compose_training_data时是存在不在ngrams_freq中的ngram的，这里是否会存在一点问题？根据我定位，初步可能是再次tokenize时，之前的是用整个句子做tokenize，但当前只是用合并的ngram字符串再次tokenize；因为tokenize时前后结果不一致导致这个问题；不知你有何看法。
3. 另外，最后的返回的predictions中是否也应该包含对initial_pos_pool的进行预测取得分呢？因为正样本本身就应该是关键性短语。个人看法，如有问题请解答。
